### PR TITLE
Win snippets eis v2

### DIFF
--- a/docs/custom-geospatial-query-extension.md
+++ b/docs/custom-geospatial-query-extension.md
@@ -8,7 +8,7 @@ __Action__: Contact your IBM representative to get your IBM Environmental Intell
 
 ### Identify Datasets
 
-Log into IBM Environmental Intelligence Suite (weatheroperationscenter.ibm.com), navigate to Geospatial Analytics using left-nav menu and use Data Explorer to search for relevant datasets.
+Log into IBM Environmental Intelligence Suite (https://environmentalintelligencesuite.ibm.com/), navigate to Geospatial Analytics using left-nav menu and use Data Explorer to search for relevant datasets.
 
 ### Areas of Interest
 

--- a/docs/custom-geospatial-query-extension.md
+++ b/docs/custom-geospatial-query-extension.md
@@ -1,4 +1,4 @@
-## IBM Environmental Intelligence Suite extension for Custom Geospatial Queries </h1>
+## IBM Environmental Intelligence Suite extension for Custom Geospatial Queries
 
 IBM Environmental Intelligence Suite combines the power of geospatial analytics, alerts and dashboards into a single, modernized user experience. Release 1.0 empowers our customers with basic support for visualizing results of a geospatial query and share their findings operationally through dashboard interactive map.
 
@@ -6,23 +6,23 @@ __Action__: Contact your IBM representative to get your IBM Environmental Intell
 
 ## Perform Data Exploration and Experimentation using IBM Environmental Intelligence Suite - Geospatial Analytics Component
 
- ### Identify Datasets
+### Identify Datasets
 
- Log into IBM Environmental Intelligence Suite (weatheroperationscenter.ibm.com), navigate to Geospatial Analytics using left-nav menu and use Data Explorer to search for relevant datasets.
+Log into IBM Environmental Intelligence Suite (weatheroperationscenter.ibm.com), navigate to Geospatial Analytics using left-nav menu and use Data Explorer to search for relevant datasets.
 
- ### Areas of Interest
+### Areas of Interest
 
- Draw a point/polygon, or look for an area of interest (like "Austin Texas" or "New South Wales"). Select relevant layers, etc and perform experimental queries.
+Draw a point/polygon, or look for an area of interest (like "Austin Texas" or "New South Wales"). Select relevant layers, etc and perform experimental queries.
 
- ![alt text](https://github.com/IBM/Environmental-Intelligence-Suite/blob/master/docs/resources/woc-geospatial-03.png?raw=true)
+![alt text](https://github.com/IBM/Environmental-Intelligence-Suite/blob/master/docs/resources/woc-geospatial-03.png?raw=true)
 
- ### Data Science Experiments
+### Data Science Experiments
 
- Optionally, create a new project in a data science environment (e.g, IBM Watson Studio), import your business assets and optionally, use one (or more) of the experimental queries from prior step to bring in data from PAIRS into your notebook. Do further experiments, feature selection, model construction/training, execution and persist output of model execution into a PAIRS data layer. Tutorials on how to construct and use geospatial queries are located here - https://pairs.res.ibm.com/tutorial/tutorials/api/index.html
+Optionally, create a new project in a data science environment (e.g, IBM Watson Studio), import your business assets and optionally, use one (or more) of the experimental queries from prior step to bring in data from PAIRS into your notebook. Do further experiments, feature selection, model construction/training, execution and persist output of model execution into a PAIRS data layer. Tutorials on how to construct and use geospatial queries are located here - https://pairs.res.ibm.com/tutorial/tutorials/api/index.html
 
 ### Visualization of data from EIS Geospatial Component (PAIRS)
 
- Once you have identified a specific layer in PAIRS that has the data for the time-interval of your interest, form a query similar to the example shown below, specifying your own `spatial:coordinates`, `temporal:intervals` and `layers:id`.  Subsequently, proceed to Day 0 below to operationalize it for viewing within Dashboard Visualization component of EIS.
+Once you have identified a specific layer in PAIRS that has the data for the time-interval of your interest, form a query similar to the example shown below, specifying your own `spatial:coordinates`, `temporal:intervals` and `layers:id`.  Subsequently, proceed to Day 0 below to operationalize it for viewing within Dashboard Visualization component of EIS.
 
 <a id='user-content-query-payload-1' href='#query-payload-1'></a>
 <b>Example geospatial `QUERY_PAYLOAD` that is ready to be operationalized </b>:
@@ -87,13 +87,30 @@ For example, *`registration-payload.json`*
 
 <a id="user-content-access-jwt-ex1" href="#access-jwt-ex1"></a>
 #### 1.2 Register the query
-| **Linux, macOS** | **PowerShell<sup>2,3,4</sup>** |
-|:-----------------|:-----------------------------|
-| <pre><code>curl -X POST "https://foundation.agtech.ibm.com/v2/layer/analytics/metadata" &#92;</code><br><code>  -H "accept: application/json" &#92;</code><br><code>  -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#92;</code><br><code>  -H "Content-Type: application/json; charset=UTF-8" &#92;</code><br><code>  -d @registration-payload.json</code></pre> | <pre><code>curl.exe -X POST "https://foundation.agtech.ibm.com/v2/layer/analytics/metadata" &#96;</code><br><code>  -H "accept: application/json" &#96;</code><br><code>  -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#96;</code><br><code>  -H "Content-Type: application/json; charset=UTF-8" &#96;</code><br><code>  -d @registration-payload.json</code></pre> |
+
+**Linux, macOS**
+``` shell
+curl -X POST "https://foundation.agtech.ibm.com/v2/layer/analytics/metadata" \
+  -H "accept: application/json" \
+  -H "Authorization: Bearer <ACCESS_JWT>" \
+  -H "Content-Type: application/json; charset=UTF-8" \
+  -d @registration-payload.json
+```
 * [*registration-payload.json*](#11-create-the-registration-payload)
 
-<a id='user-content-registration-response' href='#registration-response'></a>
+**PowerShell<sup>2,3,4</sup>**
+``` shell
+curl.exe -X POST "https://foundation.agtech.ibm.com/v2/layer/analytics/metadata" `
+  -H "accept: application/json" `
+  -H "Authorization: Bearer <ACCESS_JWT>" `
+  -H "Content-Type: application/json; charset=UTF-8" `
+  -d @registration-payload.json
+```
+* [*registration-payload.json*](#11-create-the-registration-payload)
+
+<!-- <a id='user-content-registration-response' href='#registration-response'></a> -->
 <b>Example Response</b>:
+{: #registration-response }
 
 ``` json
 [
@@ -133,10 +150,10 @@ For example, *`layer-config-block.json`*
         "COLOR_STEPS": [
           { "step": -1, "rgba": [ 0, 0, 8, 255 ] },
           { "step": 0, "rgba": [ 11, 0, 251, 255 ] },
-          { "step": .2, "rgba": [ 236, 0, 34, 255 ] },
-          { "step": .4, "rgba": [ 250, 93, 7, 255 ] },
-          { "step": .6, "rgba": [ 250, 249, 0, 255 ] },
-          { "step": .8, "rgba": [ 0, 239, 0, 255 ] },
+          { "step": 0.2, "rgba": [ 236, 0, 34, 255 ] },
+          { "step": 0.4, "rgba": [ 250, 93, 7, 255 ] },
+          { "step": 0.6, "rgba": [ 250, 249, 0, 255 ] },
+          { "step": 0.8, "rgba": [ 0, 239, 0, 255 ] },
           { "step": 1, "rgba": [ 1, 49, 1, 255 ] }
         ]
       },
@@ -149,20 +166,34 @@ For example, *`layer-config-block.json`*
   }}
 ```
 
-Before making the [sample request below](#add-the-layer):
+Before making the [sample request below](#user-content-add-the-layer):
 1. Modify the <b>`id`</b> to be something unique
 2. Set the desired <b>`displayName`</b>
-3. Substitute the correct <b>`dataAttributes.uuid`</b> using the `analyticsUuid` value from the [response above](#registration-response)
-4. Substitute `<ACCESS_JWT>` ([*Obtaining an Access Token*](./geospatial-api.md#obtaining-an-access-token)).
+3. Substitute the correct <b>`dataAttributes.uuid`</b> using the `analyticsUuid` value from the [response above](#user-content-registration-response)
+4. Substitute `<ACCESS_JWT>` ([*Obtaining an Access Token*](./geospatial-api.md#obtaining-an-access-token1)).
 
 Adjust `styleProperties:palette` and `unit` as appropriate. Contact your IBM representative or Expert Labs to discuss adjusting additional properties relevant to your specific geospatial analytics use-case.
 
 <a id='user-content-add-the-layer' href='#add-the-layer'></a>
 #### 2.2 Add Interactive Map (IMAP) custom layer
 <a id="user-content-access-jwt-ex2" href="#access-jwt-ex2"></a>
-| **Linux, macOS** | **PowerShell<sup>2,3,4</sup>** |
-|:-----------------|:-------------------------------|
-| <pre><code>curl -L -X PUT 'https://api.wsitrader.com/api/v1/IMAP/put-layer-config-block' &#92;</code><br><code>     -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#92;</code><br><code>     -H "Content-Type: application/json" &#92;</code><br><code>     -d @layer-config-block.json</code></pre> | <pre><code>curl.exe -L -X PUT 'https://api.wsitrader.com/api/v1/IMAP/put-layer-config-block' &#96;</code><br><code>         -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#96;</code><br><code>         -H "Content-Type: application/json" &#96;</code><br><code>         -d @layer-config-block.json</code></pre> |
+**Linux, macOS**
+
+``` shell
+curl -L -X PUT 'https://api.wsitrader.com/api/v1/IMAP/put-layer-config-block' \
+     -H "Authorization: Bearer <ACCESS_JWT>" \
+     -H "Content-Type: application/json" \
+     -d @layer-config-block.json
+```
+* [*layer-config-block.json*](#layer-config-block)
+
+**PowerShell<sup>2,3,4</sup>**
+``` shell
+curl.exe -L -X PUT 'https://api.wsitrader.com/api/v1/IMAP/put-layer-config-block' `
+         -H "Authorization: Bearer <ACCESS_JWT>" `
+         -H "Content-Type: application/json" `
+         -d @layer-config-block.json
+```
 * [*layer-config-block.json*](#layer-config-block)
 
 <b>Example response</b>:
@@ -228,9 +259,23 @@ Block Added.`
 
 #### 2. Submit the query and keep the query job id
 
-| **Linux, macOS** | **PowerShell<sup>2,3,4</sup>** |
-|:-----------------|:-------------------------------|
-| <pre><code>curl -L -X POST 'https://pairs.res.ibm.com/v2/query' &#92;</code><br><code>-H "Content-Type: application/json" &#92;</code><br><code>-H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#92;</code><br><code>-d @query-payload-temporal-update.json</code></pre>  | <pre><code>curl.exe -L -X POST 'https://pairs.res.ibm.com/v2/query' &#96;</code><br><code>-H "Content-Type: application/json" &#96;</code><br><code>-H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#96;</code><br><code>-d @query-payload-temporal-update.json</code></pre>  |
+**Linux, macOS**
+``` shell
+curl -L -X POST 'https://pairs.res.ibm.com/v2/query' \
+-H "Content-Type: application/json" \
+-H "Authorization: Bearer <ACCESS_JWT>" \
+-d @query-payload-temporal-update.json
+```
+* [*query-payload-temporal-update.json*](#query-payload-2)
+
+
+**PowerShell<sup>2,3,4</sup>**
+``` shell
+curl.exe -L -X POST 'https://pairs.res.ibm.com/v2/query' `
+-H "Content-Type: application/json" `
+-H "Authorization: Bearer <ACCESS_JWT>" `
+-d @query-payload-temporal-update.json
+```
 * [*query-payload-temporal-update.json*](#query-payload-2)
 
 <a id='user-content-query-to-merge-response' href='#query-to-merge-response'></a>
@@ -246,9 +291,17 @@ Block Added.`
 * [Query to merge `id` - `1607533200_04577287`](#query-to-merge-response)
 
 <a id="user-content-access-jwt-ex3" href="#access-jwt-ex3"></a><b>Merge Jobs</b>:
-| **Linux, macOS** | **PowerShell<sup>2,3,4</sup>** |
-|:-----------------|:-------------------------------|
-| <pre><code>curl -L -X PUT 'https://pairs.res.ibm.com/v2/queryjobs/1607533200_04490762/merge/1607533200_04577287' &#92;</code><br><code>-H "Authorization: Bearer &lt;YOUR API KEY&gt;"</code></pre> | <pre><code>curl.exe -L -X PUT 'https://pairs.res.ibm.com/v2/queryjobs/1607533200_04490762/merge/1607533200_04577287' &#96;</code><br><code>-H "Authorization: Bearer &lt;YOUR API KEY&gt;"</code></pre>  |
+**Linux, macOS**
+``` shell
+curl -L -X PUT 'https://pairs.res.ibm.com/v2/queryjobs/1607533200_04490762/merge/1607533200_04577287' \
+-H "Authorization: Bearer <YOUR API KEY>"
+```
+
+**PowerShell<sup>2,3,4</sup>**
+``` shell
+curl.exe -L -X PUT 'https://pairs.res.ibm.com/v2/queryjobs/1607533200_04490762/merge/1607533200_04577287' `
+-H "Authorization: Bearer <YOUR API KEY>"
+```
 
 As a consequence of the above operation, the output in Dashboard Visualization component would reflect computation from Sept 2020 (Day 1) rather than the original one from Aug 2020 (Day 0).
 

--- a/docs/custom-geospatial-query-extension.md
+++ b/docs/custom-geospatial-query-extension.md
@@ -108,9 +108,9 @@ curl.exe -X POST "https://foundation.agtech.ibm.com/v2/layer/analytics/metadata"
 ```
 * [*registration-payload.json*](#11-create-the-registration-payload)
 
-<!-- <a id='user-content-registration-response' href='#registration-response'></a> -->
+<a id='registration-response' href='#registration-response'></a>
 <b>Example Response</b>:
-{: #registration-response }
+<!-- {: #registration-response } -->
 
 ``` json
 [

--- a/docs/custom-geospatial-query-extension.md
+++ b/docs/custom-geospatial-query-extension.md
@@ -8,7 +8,7 @@ __Action__: Contact your IBM representative to get your IBM Environmental Intell
 
 ### Identify Datasets
 
-Log into IBM Environmental Intelligence Suite (https://environmentalintelligencesuite.ibm.com/), navigate to Geospatial Analytics using left-nav menu and use Data Explorer to search for relevant datasets.
+Log into [IBM Environmental Intelligence Suite](https://environmentalintelligencesuite.ibm.com/), navigate to Geospatial Analytics using left-nav menu and use Data Explorer to search for relevant datasets.
 
 ### Areas of Interest
 

--- a/docs/custom-geospatial-query-extension.md
+++ b/docs/custom-geospatial-query-extension.md
@@ -51,7 +51,7 @@ Once you have identified a specific layer in PAIRS that has the data for the tim
 ### Generate JWT token
 
 Get an access token:
-1. Follow the steps in [Geospatial Analytics API - Obtaining an Access Token](./geospatial-api.md#obtaining-an-access-token) to obtain the token indicated by `<ACCESS_JWT>`
+1. Follow the steps in [Geospatial Analytics API - Obtaining an Access Token](./geospatial-api.md#obtaining-an-access-token1) to obtain the token indicated by `<ACCESS_JWT>`
 2. Copy the value corresponding to `<ACCESS_JWT>` from the step above to use in the [registration API call below](#12-register-the-query).
 
 ### Registration Part # 1 - Platform metadata

--- a/docs/custom-geospatial-query-extension.md
+++ b/docs/custom-geospatial-query-extension.md
@@ -24,7 +24,7 @@ Optionally, create a new project in a data science environment (e.g, IBM Watson 
 
 Once you have identified a specific layer in PAIRS that has the data for the time-interval of your interest, form a query similar to the example shown below, specifying your own `spatial:coordinates`, `temporal:intervals` and `layers:id`.  Subsequently, proceed to Day 0 below to operationalize it for viewing within Dashboard Visualization component of EIS.
 
-<a id='user-content-query-payload-1' href='#query-payload-1'></a>
+<a id='query-payload-1' href='#query-payload-1'></a>
 <b>Example geospatial `QUERY_PAYLOAD` that is ready to be operationalized </b>:
 ``` json
 {
@@ -74,7 +74,7 @@ The [example Geospatial Analytics](#query-payload-1) is shown below in [*Create 
 encoded as a string with embedded JSON quote characters escaped and newlines removed.
 
 #### 1.1 Create the registration payload
-Create a JSON file with the [query registration payload](#query-registration-payload).
+Create a JSON file with the query registration payload as shown below.
 
 For example, *`registration-payload.json`*
 ``` json
@@ -83,9 +83,9 @@ For example, *`registration-payload.json`*
   "analyticsName": "query-registration-ex-pt1"
 }
 ```
-* [*example query payload*](#query-payload-1) is formatted as described in [Query registration payload](#query-registration-payload)
+* [*example query payload*](#query-payload-1) above is formatted as described in [Query registration payload](#query-registration-payload)
 
-<a id="user-content-access-jwt-ex1" href="#access-jwt-ex1"></a>
+<a id="access-jwt-ex1" href="#access-jwt-ex1"></a>
 #### 1.2 Register the query
 
 **Linux, macOS**
@@ -110,8 +110,6 @@ curl.exe -X POST "https://foundation.agtech.ibm.com/v2/layer/analytics/metadata"
 
 <a id='registration-response' href='#registration-response'></a>
 <b>Example Response</b>:
-<!-- {: #registration-response } -->
-
 ``` json
 [
   {
@@ -125,7 +123,7 @@ curl.exe -X POST "https://foundation.agtech.ibm.com/v2/layer/analytics/metadata"
 ### Registration Part # 2 - Visualization metadata
 
 #### 2.1 Create the layer config payload
-<a id='user-content-layer-config-block' href='#layer-config-block'></a>
+<a id='layer-config-block' href='#layer-config-block'></a>
 For example, *`layer-config-block.json`*
 ``` json
 {"VIEWERSHIP_ROLE" : "ALL", "CONFIG_BLOCK": {
@@ -166,17 +164,17 @@ For example, *`layer-config-block.json`*
   }}
 ```
 
-Before making the [sample request below](#user-content-add-the-layer):
+Before making the [sample request below](#add-the-layer):
 1. Modify the <b>`id`</b> to be something unique
 2. Set the desired <b>`displayName`</b>
-3. Substitute the correct <b>`dataAttributes.uuid`</b> using the `analyticsUuid` value from the [response above](#user-content-registration-response)
+3. Substitute the correct <b>`dataAttributes.uuid`</b> using the `analyticsUuid` value from the [response above](#registration-response)
 4. Substitute `<ACCESS_JWT>` ([*Obtaining an Access Token*](./geospatial-api.md#obtaining-an-access-token1)).
 
 Adjust `styleProperties:palette` and `unit` as appropriate. Contact your IBM representative or Expert Labs to discuss adjusting additional properties relevant to your specific geospatial analytics use-case.
 
-<a id='user-content-add-the-layer' href='#add-the-layer'></a>
+<a id='add-the-layer' href='#add-the-layer'></a>
 #### 2.2 Add Interactive Map (IMAP) custom layer
-<a id="user-content-access-jwt-ex2" href="#access-jwt-ex2"></a>
+<a id="access-jwt-ex2" href="#access-jwt-ex2"></a>
 **Linux, macOS**
 
 ``` shell
@@ -229,7 +227,7 @@ Block Added.`
 ### For a subsequent query run, the query temporal interval could change (for instance to 2020-09-01 to 2020-09-30)
 
 #### 1. Create query payload
-<a id='user-content-query-payload-2' href='#query-payload-2'></a>
+<a id='query-payload-2' href='#query-payload-2'></a>
 *`query-payload-temporal-update.json`*
 ``` json
 {
@@ -278,7 +276,7 @@ curl.exe -L -X POST 'https://pairs.res.ibm.com/v2/query' `
 ```
 * [*query-payload-temporal-update.json*](#query-payload-2)
 
-<a id='user-content-query-to-merge-response' href='#query-to-merge-response'></a>
+<a id='query-to-merge-response' href='#query-to-merge-response'></a>
 <b>Example Response</b>:
 ``` json
 {
@@ -290,7 +288,7 @@ curl.exe -L -X POST 'https://pairs.res.ibm.com/v2/query' `
 * [Original `baseComputationId` - `1607533200_04490762`](#registration-response)
 * [Query to merge `id` - `1607533200_04577287`](#query-to-merge-response)
 
-<a id="user-content-access-jwt-ex3" href="#access-jwt-ex3"></a><b>Merge Jobs</b>:
+<a id="access-jwt-ex3" href="#access-jwt-ex3"></a><b>Merge Jobs</b>:
 **Linux, macOS**
 ``` shell
 curl -L -X PUT 'https://pairs.res.ibm.com/v2/queryjobs/1607533200_04490762/merge/1607533200_04577287' \
@@ -308,11 +306,11 @@ As a consequence of the above operation, the output in Dashboard Visualization c
 Navigate to Environmental Intelligence Suite and verify that the query results reflect computational change due to temporal movement from Day 0 to Day 1.
 
 ---
-<a id='user-content-sup-1' href='#sup-1'></a>
+<a id='sup-1' href='#sup-1'></a>
 <sup>1</sup> [`JSON Web Token`](https://en.wikipedia.org/wiki/JSON_Web_Token)<br>
-<a id='user-content-sup-2' href='#sup-2'></a>
+<a id='sup-2' href='#sup-2'></a>
 <sup>2</sup> Backtick/Backquote `` ` `` [PowerShell Quoting Rules](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules)<br>
-<a id='user-content-sup-3' href='#sup-3'></a>
+<a id='sup-3' href='#sup-3'></a>
 <sup>3</sup> When pasting from the clipboard into PowerShell, double quotes (`"`) should be escaped (`\"`)<br>
-<a id='user-content-sup-4' href='#sup-4'></a>
+<a id='sup-4' href='#sup-4'></a>
 <sup>4</sup> [Tar and Curl Come to Windows!](https://techcommunity.microsoft.com/t5/containers/tar-and-curl-come-to-windows/ba-p/382409)

--- a/docs/custom-geospatial-query-extension.md
+++ b/docs/custom-geospatial-query-extension.md
@@ -277,7 +277,7 @@ curl.exe -L -X POST 'https://pairs.res.ibm.com/v2/query' `
 * [*query-payload-temporal-update.json*](#query-payload-2)
 
 <a id='query-to-merge-response' href='#query-to-merge-response'></a>
-<b>Example Response</b>:
+<b>Query to merge response</b>:
 ``` json
 {
     "id": "1607533200_04577287"

--- a/docs/custom-geospatial-query-extension.md
+++ b/docs/custom-geospatial-query-extension.md
@@ -8,7 +8,7 @@ __Action__: Contact your IBM representative to get your IBM Environmental Intell
 
  ### Identify Datasets
 
- Log into IBM Environmental Intelligence Suite (https://environmentalintelligencesuite.ibm.com/), navigate to Geospatial Analytics using left-nav menu and use Data Explorer to search for relevant datasets.
+ Log into IBM Environmental Intelligence Suite (weatheroperationscenter.ibm.com), navigate to Geospatial Analytics using left-nav menu and use Data Explorer to search for relevant datasets.
 
  ### Areas of Interest
 
@@ -24,9 +24,9 @@ __Action__: Contact your IBM representative to get your IBM Environmental Intell
 
  Once you have identified a specific layer in PAIRS that has the data for the time-interval of your interest, form a query similar to the example shown below, specifying your own `spatial:coordinates`, `temporal:intervals` and `layers:id`.  Subsequently, proceed to Day 0 below to operationalize it for viewing within Dashboard Visualization component of EIS.
 
+<a id='user-content-query-payload-1' href='#query-payload-1'></a>
 <b>Example geospatial `QUERY_PAYLOAD` that is ready to be operationalized </b>:
-
-``` shell
+``` json
 {
  "spatial": {
     "type":"square",
@@ -52,20 +52,47 @@ __Action__: Contact your IBM representative to get your IBM Environmental Intell
 
 Get an access token:
 1. Follow the steps in [Geospatial Analytics API - Obtaining an Access Token](./geospatial-api.md#obtaining-an-access-token) to obtain the token indicated by `<ACCESS_JWT>`
-2. Copy the value corresponding to `<ACCESS_JWT>` from the step above to use in the Import API call below.
+2. Copy the value corresponding to `<ACCESS_JWT>` from the step above to use in the [registration API call below](#12-register-the-query).
 
 ### Registration Part # 1 - Platform metadata
 
-<a id="user-content-access-jwt-ex1" href="#access-jwt-ex1"></a><b>Substitute `ACCESS_JWT`, your `QUERY_PAYLOAD` and `ANALYTICS_NAME` below - and make the curl request in a terminal window : </b>:
+#### Query registration payload
+The JSON body of a query registration request contains the Geospatial Analytics (PAIRS) query.
+It is expected that the query JSON is:
+1. Encoded as a string in the `pairsPayload` property;
+2. Quotes within the query JSON are escaped e.g. `\"` and newlines removed.
 
-``` shell
-curl -X POST "https://foundation.agtech.ibm.com/v2/layer/analytics/metadata" \
-  -H "accept: application/json" \
-  -H "Authorization: Bearer <ACCESS_JWT>" \
-  -H "Content-Type: application/json; charset=UTF-8" \
-  -d "{\"pairsPayload\":\"<QUERY_PAYLOAD>\",\"analyticsName\":\"<ANALYTICS_NAME>\"}"
+Query registration uses the API call [`/v2/layer/analytics/metadata`](https://foundation.agtech.ibm.com/v2/swagger/#/Custom%20Layers/registerAnalytic). Example payload value:
+```
+{
+  "pairsPayload": "string",
+  "analyticsName": "string"
+}
 ```
 
+The [example Geospatial Analytics](#query-payload-1) is shown below in [*Create the registration payload*](#11-create-the-registration-payload)
+encoded as a string with embedded JSON quote characters escaped and newlines removed.
+
+#### 1.1 Create the registration payload
+Create a JSON file with the [query registration payload](#query-registration-payload).
+
+For example, *`registration-payload.json`*
+``` json
+{
+  "pairsPayload": "{ \"spatial\": { \"type\":\"square\", \"aoi\":null, \"coordinates\":[38,-122,39,-121] }, \"temporal\":{ \"intervals\":[{ \"start\":\"2020-08-01\", \"end\":\"2020-08-31\" }] }, \"layers\":[{ \"id\":\"51\", \"type\":\"raster\" }]}",
+  "analyticsName": "query-registration-ex-pt1"
+}
+```
+* [*example query payload*](#query-payload-1) is formatted as described in [Query registration payload](#query-registration-payload)
+
+<a id="user-content-access-jwt-ex1" href="#access-jwt-ex1"></a>
+#### 1.2 Register the query
+| **Linux, macOS** | **PowerShell<sup>2,3,4</sup>** |
+|:-----------------|:-----------------------------|
+| <pre><code>curl -X POST "https://foundation.agtech.ibm.com/v2/layer/analytics/metadata" &#92;</code><br><code>  -H "accept: application/json" &#92;</code><br><code>  -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#92;</code><br><code>  -H "Content-Type: application/json; charset=UTF-8" &#92;</code><br><code>  -d @registration-payload.json</code></pre> | <pre><code>curl.exe -X POST "https://foundation.agtech.ibm.com/v2/layer/analytics/metadata" &#96;</code><br><code>  -H "accept: application/json" &#96;</code><br><code>  -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#96;</code><br><code>  -H "Content-Type: application/json; charset=UTF-8" &#96;</code><br><code>  -d @registration-payload.json</code></pre> |
+* [*registration-payload.json*](#11-create-the-registration-payload)
+
+<a id='user-content-registration-response' href='#registration-response'></a>
 <b>Example Response</b>:
 
 ``` json
@@ -80,17 +107,11 @@ curl -X POST "https://foundation.agtech.ibm.com/v2/layer/analytics/metadata" \
 
 ### Registration Part # 2 - Visualization metadata
 
-
- Before making the sample request below, modify the <b>`id`</b> to be something unique, set the desired <b>`displayName`</b> and substitute the correct <b>`dataAttributes:uuid`</b> using the `analyticsUuid` value from the response above. <a id="user-content-access-jwt-ex2" href="#access-jwt-ex2"></a>Also, substitute ACCESS_JWT
-
- Adjust `styleProperties:palette` and `unit` as appropriate. Contact your IBM representative or Expert Labs to discuss adjusting additional properties relevant to your specific geospatial analytics use-case.
-
-
-``` shell
-curl --location --request PUT 'https://api.wsitrader.com/api/v1/IMAP/put-layer-config-block' \
---header 'Authorization: Bearer <ACCESS_JWT>' \
---header 'Content-Type: application/json' \
---data '{"VIEWERSHIP_ROLE" : "ALL", "CONFIG_BLOCK": {
+#### 2.1 Create the layer config payload
+<a id='user-content-layer-config-block' href='#layer-config-block'></a>
+For example, *`layer-config-block.json`*
+``` json
+{"VIEWERSHIP_ROLE" : "ALL", "CONFIG_BLOCK": {
     "id": "customQuery-staging-test01",
     "modelRegistryId": null,
     "displayName": "Staging Test - Custom Query 01",
@@ -125,22 +146,33 @@ curl --location --request PUT 'https://api.wsitrader.com/api/v1/IMAP/put-layer-c
       "extendMaximumColor": true,
       "invalidDataValue": -9999
     }
-  }}'
+  }}
 ```
+
+Before making the [sample request below](#add-the-layer):
+1. Modify the <b>`id`</b> to be something unique
+2. Set the desired <b>`displayName`</b>
+3. Substitute the correct <b>`dataAttributes.uuid`</b> using the `analyticsUuid` value from the [response above](#registration-response)
+4. Substitute `<ACCESS_JWT>` ([*Obtaining an Access Token*](./geospatial-api.md#obtaining-an-access-token)).
+
+Adjust `styleProperties:palette` and `unit` as appropriate. Contact your IBM representative or Expert Labs to discuss adjusting additional properties relevant to your specific geospatial analytics use-case.
+
+<a id='user-content-add-the-layer' href='#add-the-layer'></a>
+#### 2.2 Add Interactive Map (IMAP) custom layer
+<a id="user-content-access-jwt-ex2" href="#access-jwt-ex2"></a>
+| **Linux, macOS** | **PowerShell<sup>2,3,4</sup>** |
+|:-----------------|:-------------------------------|
+| <pre><code>curl -L -X PUT 'https://api.wsitrader.com/api/v1/IMAP/put-layer-config-block' &#92;</code><br><code>     -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#92;</code><br><code>     -H "Content-Type: application/json" &#92;</code><br><code>     -d @layer-config-block.json</code></pre> | <pre><code>curl.exe -L -X PUT 'https://api.wsitrader.com/api/v1/IMAP/put-layer-config-block' &#96;</code><br><code>         -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#96;</code><br><code>         -H "Content-Type: application/json" &#96;</code><br><code>         -d @layer-config-block.json</code></pre> |
+* [*layer-config-block.json*](#layer-config-block)
 
 <b>Example response</b>:
 
 `Response: 200
 Block Added.`
 
-
-
-
-
-
 ## Navigate to IBM Environmental Intelligence Suite - Dashboard Visualization
 
-1. Login to IBM Environmental Intelligence Suite with your username and password by launching https://environmentalintelligencesuite.ibm.com - and navigate to Dashboard Visualization -> Interactive Map
+1. Login to IBM Environmental Intelligence Suite with your username and password by launching https://environmentalintelligencesuite.ibm.com/ - and navigate to Dashboard Visualization -> Interactive Map
 
 ![alt text](https://github.com/IBM/Environmental-Intelligence-Suite/blob/master/docs/resources/woc-maximo01.png?raw=true)
 
@@ -165,14 +197,11 @@ Block Added.`
 
 ### For a subsequent query run, the query temporal interval could change (for instance to 2020-09-01 to 2020-09-30)
 
-
-<b>Call to</b>:
-
-``` shell
-curl --location --request POST 'https://pairs.res.ibm.com/v2/query' \
---header 'Content-Type: application/json' \
---header 'Authorization: Bearer <ACCESS_JWT>' \
---data '{
+#### 1. Create query payload
+<a id='user-content-query-payload-2' href='#query-payload-2'></a>
+*`query-payload-temporal-update.json`*
+``` json
+{
     "spatial": {
         "type": "square",
         "coordinates": [
@@ -194,11 +223,18 @@ curl --location --request POST 'https://pairs.res.ibm.com/v2/query' \
             "type": "raster"
         }
     ]
-}'
+}
 ```
 
-<b>Example Response</b>:
+#### 2. Submit the query and keep the query job id
 
+| **Linux, macOS** | **PowerShell<sup>2,3,4</sup>** |
+|:-----------------|:-------------------------------|
+| <pre><code>curl -L -X POST 'https://pairs.res.ibm.com/v2/query' &#92;</code><br><code>-H "Content-Type: application/json" &#92;</code><br><code>-H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#92;</code><br><code>-d @query-payload-temporal-update.json</code></pre>  | <pre><code>curl.exe -L -X POST 'https://pairs.res.ibm.com/v2/query' &#96;</code><br><code>-H "Content-Type: application/json" &#96;</code><br><code>-H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#96;</code><br><code>-d @query-payload-temporal-update.json</code></pre>  |
+* [*query-payload-temporal-update.json*](#query-payload-2)
+
+<a id='user-content-query-to-merge-response' href='#query-to-merge-response'></a>
+<b>Example Response</b>:
 ``` json
 {
     "id": "1607533200_04577287"
@@ -206,14 +242,24 @@ curl --location --request POST 'https://pairs.res.ibm.com/v2/query' \
 ```
 
 ### Merge the new job with original baseComputationId from Day 0 - Registration Part # 1 above
+* [Original `baseComputationId` - `1607533200_04490762`](#registration-response)
+* [Query to merge `id` - `1607533200_04577287`](#query-to-merge-response)
 
 <a id="user-content-access-jwt-ex3" href="#access-jwt-ex3"></a><b>Merge Jobs</b>:
-
-``` shell
-curl --location --request PUT 'https://pairs.res.ibm.com/v2/queryjobs/1607533200_04490762/merge/1607533200_04577287' \
---header 'Authorization: Bearer <ACCESS_JWT>'
-```
+| **Linux, macOS** | **PowerShell<sup>2,3,4</sup>** |
+|:-----------------|:-------------------------------|
+| <pre><code>curl -L -X PUT 'https://pairs.res.ibm.com/v2/queryjobs/1607533200_04490762/merge/1607533200_04577287' &#92;</code><br><code>-H "Authorization: Bearer &lt;YOUR API KEY&gt;"</code></pre> | <pre><code>curl.exe -L -X PUT 'https://pairs.res.ibm.com/v2/queryjobs/1607533200_04490762/merge/1607533200_04577287' &#96;</code><br><code>-H "Authorization: Bearer &lt;YOUR API KEY&gt;"</code></pre>  |
 
 As a consequence of the above operation, the output in Dashboard Visualization component would reflect computation from Sept 2020 (Day 1) rather than the original one from Aug 2020 (Day 0).
 
 Navigate to Environmental Intelligence Suite and verify that the query results reflect computational change due to temporal movement from Day 0 to Day 1.
+
+---
+<a id='user-content-sup-1' href='#sup-1'></a>
+<sup>1</sup> [`JSON Web Token`](https://en.wikipedia.org/wiki/JSON_Web_Token)<br>
+<a id='user-content-sup-2' href='#sup-2'></a>
+<sup>2</sup> Backtick/Backquote `` ` `` [PowerShell Quoting Rules](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules)<br>
+<a id='user-content-sup-3' href='#sup-3'></a>
+<sup>3</sup> When pasting from the clipboard into PowerShell, double quotes (`"`) should be escaped (`\"`)<br>
+<a id='user-content-sup-4' href='#sup-4'></a>
+<sup>4</sup> [Tar and Curl Come to Windows!](https://techcommunity.microsoft.com/t5/containers/tar-and-curl-come-to-windows/ba-p/382409)

--- a/docs/geospatial-api.md
+++ b/docs/geospatial-api.md
@@ -50,13 +50,20 @@ An API endpoint is provided that accepts a JSON object and will return a JSON re
 - **Expected Data:** `{"apiKey":"xxxxxxxx", "clientId":"ibm-pairs"}`
 
 For example:
-
-``` shell
-curl --request POST \
-     --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient \
-     --header 'Content-Type: application/json' \
-     --data '{"apiKey":"xxxxxxxx", "clientId":"ibm-pairs"}'
-```
+<table>
+  <thead>
+    <tr>
+      <th style="text-align: left"><strong>Linux, macOS</strong></th>
+      <th style="text-align: left"><strong>PowerShell<sup>2,3,4</sup></strong></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="text-align: left"><pre><code>curl -X POST &#92;</code><br><code>     --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#92;</code><br><code>     -H "Content-Type: application/json" &#92;</code><br><code>     -d '{"apiKey":"&lt;YOUR API KEY&gt;", "clientId":"ibm-pairs"}'</code></pre></td>
+      <td style="text-align: left"><pre><code>curl.exe -X POST &#96;</code><br><code>         --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#96;</code><br><code>         -H "Content-Type: application/json" &#96;</code><br><code>         -d '{&#92;"apiKey&#92;":&#92;"&lt;YOUR API KEY&gt;&#92;", &#92;"clientId&#92;":&#92;"ibm-pairs&#92;"}'</code></pre></td>
+    </tr>
+  </tbody>
+</table>
 
 The result of **POST** `/auth/GetBearerForClient` will produce:
 

--- a/docs/geospatial-api.md
+++ b/docs/geospatial-api.md
@@ -7,8 +7,9 @@ Geospatial Analytics API endpoints require an authenticated access token to be p
 HTTP Authorization header Bearer realm. For example:
 
 ``` text
-Authorization: Bearer xxxxxxxx
+Authorization: Bearer <JSON Web Token>
 ```
+* *See* [Obtaining an access token](#obtaining-an-access-token)<sup>1</sup>
 
 Geospatial Analytics uses the IBM Environmental Intelligence Suite authorization server to provide API access.
 The Environmental Intelligence Suite authorization server implements standard OAuth 2.0 and OpenId Connect 1.0 protocols.
@@ -39,31 +40,15 @@ below provides details.
 8. Geospatial Analytics API response payload; and the process to make API requests and refresh access token continues
 
 ### Obtaining an Access Token
-* **Tutorial usages**
-    * <a href="./custom-geospatial-query-extension.md#access-jwt-ex1">`<ACCESS_JWT>` - Registration Part # 1 - Platform metadata</a>
-    * <a href="./custom-geospatial-query-extension.md#access-jwt-ex2">`<ACCESS_JWT>` - Registration Part # 2 - Visualization metadata</a>
-    * <a href="./custom-geospatial-query-extension.md#access-jwt-ex3">`<ACCESS_JWT>` - Merge the new job with original baseComputationId</a>
+* **Tutorial examples where an access token is used**
+    * See *`<ACCESS_JWT>`* in:
+        * [Registration Part # 1 - Platform metadata](./custom-geospatial-query-extension.md#access-jwt-ex1)
+        * [Registration Part # 2 - Visualization metadata](./custom-geospatial-query-extension.md#access-jwt-ex2)
+        * [Merge the new job with original `baseComputationId`](./custom-geospatial-query-extension.md#access-jwt-ex3)
 
-An API endpoint is provided that accepts a JSON object and will return a JSON response containing an access token:
-- **POST** https://auth-b2b-twc.ibm.com/auth/GetBearerForClient
-- **Content-Type:** `application/json`
-- **Expected Data:** `{"apiKey":"xxxxxxxx", "clientId":"ibm-pairs"}`
-
-For example:
-<table>
-  <thead>
-    <tr>
-      <th style="text-align: left"><strong>Linux, macOS</strong></th>
-      <th style="text-align: left"><strong>PowerShell<sup>2,3,4</sup></strong></th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td style="text-align: left"><pre><code>curl -X POST &#92;</code><br><code>     --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#92;</code><br><code>     -H "Content-Type: application/json" &#92;</code><br><code>     -d '{"apiKey":"&lt;YOUR API KEY&gt;", "clientId":"ibm-pairs"}'</code></pre></td>
-      <td style="text-align: left"><pre><code>curl.exe -X POST &#96;</code><br><code>         --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#96;</code><br><code>         -H "Content-Type: application/json" &#96;</code><br><code>         -d '{&#92;"apiKey&#92;":&#92;"&lt;YOUR API KEY&gt;&#92;", &#92;"clientId&#92;":&#92;"ibm-pairs&#92;"}'</code></pre></td>
-    </tr>
-  </tbody>
-</table>
+| **Linux, macOS** | **PowerShell<sup>2,3,4</sup>** |
+|:-----------------|:-----------------------------|
+| <pre><code>curl -X POST &#92;</code><br><code>     --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#92;</code><br><code>     -H "Content-Type: application/json" &#92;</code><br><code>     -d '{"apiKey":"&lt;YOUR API KEY&gt;", "clientId":"ibm-pairs"}'</code></pre> |  <pre><code>curl.exe -X POST &#96;</code><br><code>         --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#96;</code><br><code>         -H "Content-Type: application/json" &#96;</code><br><code>         -d '{\\"apiKey\\":\\"&lt;YOUR API KEY&gt;\\", \\"clientId\\":\\"ibm-pairs\\"}'</code></pre> |
 
 The result of **POST** `/auth/GetBearerForClient` will produce:
 
@@ -83,13 +68,9 @@ which submits a Geospatial Analytics API query request.
 In this example, the value of the `access_token` property in the response above is used as the value for
 the`Authorization` header Bearer realm in a request to the Geospatial Analytics API `/v2/query` endpoint.
 
-``` shell
-curl --request POST \
-     --url https://pairs.res.ibm.com/v2/query \
-     --header 'Content-Type: application/json' \
-     --header 'Authorization: Bearer <ACCESS_JWT>' \
-     --data '{...omitted for brevity...}'
-```
+| **Linux, macOS**                                                 | **PowerShell<sup>2,3,4</sup>** |
+|:-----------------------------------------------------------------|:------------------------------|
+| <pre><code>curl -X POST --url https://pairs.res.ibm.com/v2/query &#92;</code><br><code>     -H "Content-Type: application/json" &#92;</code><br><code>     -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#92;</code><br><code>     -d '{...omitted for brevity...}'</code></pre> | <pre><code>curl.exe -X POST --url https://pairs.res.ibm.com/v2/query &#96;</code><br><code>         -H "Content-Type: application/json" &#96;</code><br><code>         -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#96;</code><br><code>         -d '{...omitted for brevity...}'</code></pre> |
 
 ### Refreshing an Access Token
 
@@ -102,15 +83,20 @@ When an access token expires, the `refresh_token` property value of `/auth/GetBe
 `/connect/token` JSON responses can be used to request a new `access_token` without re-authenticating
 with your API key as follows:
 
-``` shell
-curl --request POST \
-     --url https://auth-b2b-twc.ibm.com/connect/token \
-     --header 'Content-Type: application/x-www-form-urlencoded' \
-     --data-urlencode "grant_type=refresh_token" \
-     --data-urlencode "client_id=ibm-pairs" \
-     --data-urlencode "refresh_token=<REFRESH TOKEN>"
-```
+| **Linux, macOS**                                                 | **PowerShell<sup>2,3,4</sup>** |
+|:-----------------------------------------------------------------|:------------------------------|
+| <pre><code>curl -X POST https://auth-b2b-twc.ibm.com/connect/token &#92;</code><br><code>     -H "Content-Type: application/x-www-form-urlencoded" &#92;</code><br><code>     --data-urlencode "grant_type=refresh_token" &#92;</code><br><code>     --data-urlencode "client_id=ibm-pairs" &#92;</code><br><code>     --data-urlencode "refresh_token=&lt;REFRESH TOKEN&gt;"</code></pre> | <pre><code>curl.exe -X POST https://auth-b2b-twc.ibm.com/connect/token &#96;</code><br><code>     -H "Content-Type: application/x-www-form-urlencoded" &#96;</code><br><code>     --data-urlencode "grant_type=refresh_token" &#96;</code><br><code>     --data-urlencode "client_id=ibm-pairs" &#96;</code><br><code>     --data-urlencode "refresh_token=&lt;REFRESH TOKEN&gt;"</code></pre> |
 
 The result of **POST** `/connect/token` will produce a JSON response payload with a new `access_token` and
 `refresh_token` to use in subsequent Geospatial Analytics API and authorization server requests
 where applicable..
+
+---
+<a id='user-content-sup-1' href='#sup-1'></a>
+<sup>1</sup> [`JSON Web Token`](https://en.wikipedia.org/wiki/JSON_Web_Token)<br>
+<a id='user-content-sup-2' href='#sup-2'></a>
+<sup>2</sup> Backtick/Backquote `` ` `` [PowerShell Quoting Rules](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules)<br>
+<a id='user-content-sup-3' href='#sup-3'></a>
+<sup>3</sup> When pasting from the clipboard into PowerShell, double quotes (`"`) should be escaped (`\"`)<br>
+<a id='user-content-sup-4' href='#sup-4'></a>
+<sup>4</sup> [Tar and Curl Come to Windows!](https://techcommunity.microsoft.com/t5/containers/tar-and-curl-come-to-windows/ba-p/382409)

--- a/docs/geospatial-api.md
+++ b/docs/geospatial-api.md
@@ -46,9 +46,9 @@ below provides details.
 ### Obtaining an Access Token<sup>1</sup>
 * **Tutorial examples where an access token is used**
     * See *`<ACCESS_JWT>`* in:
-        * [Registration Part # 1 - Platform metadata](./custom-geospatial-query-extension.md#access-jwt-ex1)
-        * [Registration Part # 2 - Visualization metadata](./custom-geospatial-query-extension.md#access-jwt-ex2)
-        * [Merge the new job with original `baseComputationId`](./custom-geospatial-query-extension.md#access-jwt-ex3)
+        * [Registration Part # 1 - Platform metadata](./custom-geospatial-query-extension#access-jwt-ex1)
+        * [Registration Part # 2 - Visualization metadata](./custom-geospatial-query-extension#access-jwt-ex2)
+        * [Merge the new job with original `baseComputationId`](./custom-geospatial-query-extension#access-jwt-ex3)
 
 **Linux, macOS**
 

--- a/docs/geospatial-api.md
+++ b/docs/geospatial-api.md
@@ -2,6 +2,10 @@
 
 ## Authentication
 
+1. [Overview](#overview)
+2. [Get an access token](#obtaining-an-access-token1)
+3. [Refresh an access token](#refreshing-an-access-token)
+
 ### Overview
 Geospatial Analytics API endpoints require an authenticated access token to be provided as an
 HTTP Authorization header Bearer realm. For example:
@@ -15,10 +19,10 @@ Geospatial Analytics uses the IBM Environmental Intelligence Suite authorization
 The Environmental Intelligence Suite authorization server implements standard OAuth 2.0 and OpenId Connect 1.0 protocols.
 
 Authorization server endpoints are located at the base Uri:
-- https://auth-b2b-twc.ibm.com/
+- [https://auth-b2b-twc.ibm.com/](https://auth-b2b-twc.ibm.com/)
 
 An OpenId Connect discovery document for the authorization server is located at the Uri:
-- https://auth-b2b-twc.ibm.com/.well-known/openid-configuration
+- [https://auth-b2b-twc.ibm.com/.well-known/openid-configuration](https://auth-b2b-twc.ibm.com/.well-known/openid-configuration)
 
 To make Geospatial Analytics API requests an API key is provided to obtain an access token
 which is then used in API requests to confirm authentication and to execute further authorization controls.
@@ -39,31 +43,30 @@ below provides details.
 7. The new access token is used for Geospatial Analytics API requests
 8. Geospatial Analytics API response payload; and the process to make API requests and refresh access token continues
 
-### Obtaining an Access Token
+### Obtaining an Access Token<sup>1</sup>
 * **Tutorial examples where an access token is used**
     * See *`<ACCESS_JWT>`* in:
         * [Registration Part # 1 - Platform metadata](./custom-geospatial-query-extension.md#access-jwt-ex1)
         * [Registration Part # 2 - Visualization metadata](./custom-geospatial-query-extension.md#access-jwt-ex2)
         * [Merge the new job with original `baseComputationId`](./custom-geospatial-query-extension.md#access-jwt-ex3)
 
-| **Linux, macOS** | **PowerShell<sup>2,3,4</sup>** |
-|:-----------------|:-----------------------------|
-| <pre><code>curl -X POST &#92;</code><br><code>     --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#92;</code><br><code>     -H "Content-Type: application/json" &#92;</code><br><code>     -d '{"apiKey":"&lt;YOUR API KEY&gt;", "clientId":"ibm-pairs"}'</code></pre> |  <pre><code>curl.exe -X POST &#96;</code><br><code>         --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#96;</code><br><code>         -H "Content-Type: application/json" &#96;</code><br><code>         -d '{\\"apiKey\\":\\"&lt;YOUR API KEY&gt;\\", \\"clientId\\":\\"ibm-pairs\\"}'</code></pre> |
+**Linux, macOS**
 
-
-**DRAFT-TEST**
+``` shell
+curl -X POST \
+         --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient \
+         -H "Content-Type: application/json" \
+         -d '{"apiKey":"<YOUR API KEY>", "clientId":"ibm-pairs"}'
+```
 
 **PowerShell<sup>2,3,4</sup>**
-<pre lang="shell"><code>curl.exe -X POST &#96;</code><br><code>         --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#96;</code><br><code>         -H "Content-Type: application/json" &#96;</code><br><code>         -d '{&#92;"apiKey&#92;":&#92;"&lt;YOUR API KEY&gt;&#92;", &#92;"clientId&#92;":&#92;"ibm-pairs&#92;"}'</code></pre>
 
-``` powershell
+``` shell
 curl.exe -X POST `
          --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient `
          -H "Content-Type: application/json" `
          -d '{\"apiKey\":\"<YOUR API KEY>\", \"clientId\":\"ibm-pairs\"}'
 ```
-
-**EOF-DRAFT-TEST**
 
 The result of **POST** `/auth/GetBearerForClient` will produce:
 
@@ -83,9 +86,23 @@ which submits a Geospatial Analytics API query request.
 In this example, the value of the `access_token` property in the response above is used as the value for
 the`Authorization` header Bearer realm in a request to the Geospatial Analytics API `/v2/query` endpoint.
 
-| **Linux, macOS**                                                 | **PowerShell<sup>2,3,4</sup>** |
-|:-----------------------------------------------------------------|:------------------------------|
-| <pre><code>curl -X POST --url https://pairs.res.ibm.com/v2/query &#92;</code><br><code>     -H "Content-Type: application/json" &#92;</code><br><code>     -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#92;</code><br><code>     -d '{...omitted for brevity...}'</code></pre> | <pre><code>curl.exe -X POST --url https://pairs.res.ibm.com/v2/query &#96;</code><br><code>         -H "Content-Type: application/json" &#96;</code><br><code>         -H "Authorization: Bearer &lt;ACCESS_JWT&gt;" &#96;</code><br><code>         -d '{...omitted for brevity...}'</code></pre> |
+**Linux, macOS**
+``` shell
+curl --request POST \
+     --url https://pairs.res.ibm.com/v2/query \
+     --header 'Content-Type: application/json' \
+     --header 'Authorization: Bearer <ACCESS_JWT>' \
+     --data '{...omitted for brevity...}'
+```
+
+**PowerShell<sup>2,3,4</sup>**
+``` shell
+curl.exe --request POST `
+     --url https://pairs.res.ibm.com/v2/query `
+     --header 'Content-Type: application/json' `
+     --header 'Authorization: Bearer <ACCESS_JWT>' `
+     --data '{...omitted for brevity...}'
+```
 
 ### Refreshing an Access Token
 
@@ -98,9 +115,25 @@ When an access token expires, the `refresh_token` property value of `/auth/GetBe
 `/connect/token` JSON responses can be used to request a new `access_token` without re-authenticating
 with your API key as follows:
 
-| **Linux, macOS**                                                 | **PowerShell<sup>2,3,4</sup>** |
-|:-----------------------------------------------------------------|:------------------------------|
-| <pre><code>curl -X POST https://auth-b2b-twc.ibm.com/connect/token &#92;</code><br><code>     -H "Content-Type: application/x-www-form-urlencoded" &#92;</code><br><code>     --data-urlencode "grant_type=refresh_token" &#92;</code><br><code>     --data-urlencode "client_id=ibm-pairs" &#92;</code><br><code>     --data-urlencode "refresh_token=&lt;REFRESH TOKEN&gt;"</code></pre> | <pre><code>curl.exe -X POST https://auth-b2b-twc.ibm.com/connect/token &#96;</code><br><code>     -H "Content-Type: application/x-www-form-urlencoded" &#96;</code><br><code>     --data-urlencode "grant_type=refresh_token" &#96;</code><br><code>     --data-urlencode "client_id=ibm-pairs" &#96;</code><br><code>     --data-urlencode "refresh_token=&lt;REFRESH TOKEN&gt;"</code></pre> |
+**Linux, macOS**
+``` shell
+curl --request POST \
+     --url https://auth-b2b-twc.ibm.com/connect/token \
+     --header 'Content-Type: application/x-www-form-urlencoded' \
+     --data-urlencode "grant_type=refresh_token" \
+     --data-urlencode "client_id=ibm-pairs" \
+     --data-urlencode "refresh_token=<REFRESH TOKEN>"
+```
+
+**PowerShell<sup>2,3,4</sup>**
+``` shell
+curl.exe --request POST `
+     --url https://auth-b2b-twc.ibm.com/connect/token `
+     --header 'Content-Type: application/x-www-form-urlencoded' `
+     --data-urlencode "grant_type=refresh_token" `
+     --data-urlencode "client_id=ibm-pairs" `
+     --data-urlencode "refresh_token=<REFRESH TOKEN>"
+```
 
 The result of **POST** `/connect/token` will produce a JSON response payload with a new `access_token` and
 `refresh_token` to use in subsequent Geospatial Analytics API and authorization server requests

--- a/docs/geospatial-api.md
+++ b/docs/geospatial-api.md
@@ -50,6 +50,21 @@ below provides details.
 |:-----------------|:-----------------------------|
 | <pre><code>curl -X POST &#92;</code><br><code>     --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#92;</code><br><code>     -H "Content-Type: application/json" &#92;</code><br><code>     -d '{"apiKey":"&lt;YOUR API KEY&gt;", "clientId":"ibm-pairs"}'</code></pre> |  <pre><code>curl.exe -X POST &#96;</code><br><code>         --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#96;</code><br><code>         -H "Content-Type: application/json" &#96;</code><br><code>         -d '{\\"apiKey\\":\\"&lt;YOUR API KEY&gt;\\", \\"clientId\\":\\"ibm-pairs\\"}'</code></pre> |
 
+
+**DRAFT-TEST**
+
+**PowerShell<sup>2,3,4</sup>**
+<pre lang="shell"><code>curl.exe -X POST &#96;</code><br><code>         --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient &#96;</code><br><code>         -H "Content-Type: application/json" &#96;</code><br><code>         -d '{&#92;"apiKey&#92;":&#92;"&lt;YOUR API KEY&gt;&#92;", &#92;"clientId&#92;":&#92;"ibm-pairs&#92;"}'</code></pre>
+
+``` powershell
+curl.exe -X POST `
+         --url https://auth-b2b-twc.ibm.com/auth/GetBearerForClient `
+         -H "Content-Type: application/json" `
+         -d '{\"apiKey\":\"<YOUR API KEY>\", \"clientId\":\"ibm-pairs\"}'
+```
+
+**EOF-DRAFT-TEST**
+
 The result of **POST** `/auth/GetBearerForClient` will produce:
 
 ``` json


### PR DESCRIPTION
Geospatial Analytics documentation page updates:
* Changes to example snippets to include ability to copy n paste into Windows PowerShell terminal with quote (") character escaping (\") and backtick (`) multi-line escaping.

Adding changes back after we reverted with #16 
* Changes tested in markdown published via the default Jekyll static file processing in the forked repo e.g
  * https://elljoh.github.io/Environmental-Intelligence-Suite/custom-geospatial-query-extension#access-jwt-ex1
  * https://elljoh.github.io/Environmental-Intelligence-Suite/geospatial-api.html#obtaining-an-access-token1

The key difference is that a table is ***not*** used for O/S platform type snippets. The default rendering processor does not handle `<pre>` elements embedded in table cells; further, it is more readable in the source markdown document to have fewer explicit HTML elements.
