### PR TITLE
Geospatial API page links broken

### DIFF
--- a/docs/geospatial-api.md
+++ b/docs/geospatial-api.md
@@ -13,7 +13,7 @@ HTTP Authorization header Bearer realm. For example:
 ``` text
 Authorization: Bearer <JSON Web Token>
 ```
-* *See* [Obtaining an access token](#obtaining-an-access-token)<sup>1</sup>
+* *See* [Obtaining an access token](#obtaining-an-access-token1)<sup>1</sup>
 
 Geospatial Analytics uses the IBM Environmental Intelligence Suite authorization server to provide API access.
 The Environmental Intelligence Suite authorization server implements standard OAuth 2.0 and OpenId Connect 1.0 protocols.
@@ -28,7 +28,7 @@ To make Geospatial Analytics API requests an API key is provided to obtain an ac
 which is then used in API requests to confirm authentication and to execute further authorization controls.
 
 Geospatial Analytics API requests are secured by access token validation. The following diagram illustrates the API key usage flow
-for just one of the Geospatial Analytics APIs: `/v2/query`. The section [Obtaining an Access Token](#obtaining-an-access-token) further
+for just one of the Geospatial Analytics APIs: `/v2/query`. The section [Obtaining an Access Token](#obtaining-an-access-token1)<sup>1</sup> further
 below provides details.
 
 ![Geospatial-API-Authentication-Overview](resources/Geospatial-API-Authentication-Overview.png)
@@ -46,9 +46,9 @@ below provides details.
 ### Obtaining an Access Token<sup>1</sup>
 * **Tutorial examples where an access token is used**
     * See *`<ACCESS_JWT>`* in:
-        * [Registration Part # 1 - Platform metadata](./custom-geospatial-query-extension#access-jwt-ex1)
-        * [Registration Part # 2 - Visualization metadata](./custom-geospatial-query-extension#access-jwt-ex2)
-        * [Merge the new job with original `baseComputationId`](./custom-geospatial-query-extension#access-jwt-ex3)
+        * [Registration Part # 1 - Platform metadata](./custom-geospatial-query-extension.md#access-jwt-ex1)
+        * [Registration Part # 2 - Visualization metadata](./custom-geospatial-query-extension.md#access-jwt-ex2)
+        * [Merge the new job with original `baseComputationId`](./custom-geospatial-query-extension.md#access-jwt-ex3)
 
 **Linux, macOS**
 


### PR DESCRIPTION
Update links under the "**Obtaining an Access Token1**" section to include the `.md` extension. This will enable both the GitHub Pages site and the default GitHub web app browse functionality to interpret links correctly.

Links under the [geospatial-api.md#obtaining-an-access-token1](https://github.com/IBM/Environmental-Intelligence-Suite/blob/master/docs/geospatial-api.md#obtaining-an-access-token1) section in the GitHub web app markdown file view are broken (`404` return code) as a result of a missing `.md` extension.

The corresponding GitHub Pages site served by Jekyll is tolerant of the missing file extension.
e.g. navigating from the links under the section as presented below produces expected results.
* https://ibm.github.io/Environmental-Intelligence-Suite/geospatial-api.html#obtaining-an-access-token1
